### PR TITLE
List of episodes instead of single episode

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -13,7 +13,7 @@
 </div>
 
 <mat-card>
-  <app-show-episodes [episode]="episodeDetails"></app-show-episodes>
+  <app-show-episodes [current]="showDetails"></app-show-episodes>
 </mat-card>
   <!-- Footer 
   <footer>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,6 +1,5 @@
 import { Component } from '@angular/core';
 import { IShowDetailsData } from './ishow-details-data';
-import { IShowEpisodes } from './ishow-episodes';
 import { ShowDetailsService } from './show-details.service';
 
 @Component({
@@ -11,12 +10,8 @@ import { ShowDetailsService } from './show-details.service';
 export class AppComponent {
   title = 'tv-show';
   showDetails: IShowDetailsData ={
-    name: ''
-  } 
-  episodeDetails: IShowEpisodes ={
-    img:'',
     name: '',
-    summary: ''
+    episodes: []
   }
 
   constructor(private showDetailsService: ShowDetailsService) {}
@@ -24,8 +19,6 @@ export class AppComponent {
   doSearch(searchValue: string) {
     this.showDetailsService.getShowDetails(searchValue)
     .subscribe(data => this.showDetails = data);
-    this.showDetailsService.getEpisodes(searchValue)
-    .subscribe(data => this.episodeDetails = data);
   }
 
 }

--- a/src/app/iapi-response-data.ts
+++ b/src/app/iapi-response-data.ts
@@ -1,10 +1,11 @@
-export interface IShowEpisodesData {
+export interface IApiResponseData {
+    name: string
     _embedded: {
         episodes: [{
             image: {
                 medium: string
             }
-            name: string,
+            name: string
             summary: string
         }]
     }

--- a/src/app/ishow-details-data.ts
+++ b/src/app/ishow-details-data.ts
@@ -1,3 +1,8 @@
 export interface IShowDetailsData {
     name: string
+    episodes: Array<{
+        img: string,
+        name: string,
+        summary: string
+    }>
 }

--- a/src/app/ishow-episodes.ts
+++ b/src/app/ishow-episodes.ts
@@ -1,5 +1,0 @@
-export interface IShowEpisodes {
-    img: string    
-    name: string
-    summary: string
-}

--- a/src/app/show-details.service.ts
+++ b/src/app/show-details.service.ts
@@ -1,8 +1,7 @@
 import { Injectable } from '@angular/core';
 import {HttpClient} from '@angular/common/http';
 import {map} from 'rxjs/operators';
-import { IShowDetailsData } from './ishow-details-data';
-import { IShowEpisodesData } from './ishow-episodes-data';
+import { IApiResponseData } from './iapi-response-data';
 
 @Injectable({
   providedIn: 'root'
@@ -12,22 +11,24 @@ export class ShowDetailsService {
   constructor(private httpClient: HttpClient) {}
 
   getShowDetails(showName: string) {
-    return this.httpClient.get<IShowDetailsData>
-    (`https://api.tvmaze.com/singlesearch/shows?q=${showName}`)
-  } 
-  
-  getEpisodes(showName: string){
-    return this.httpClient.get<IShowEpisodesData>
+    return this.httpClient.get<IApiResponseData>
     (`https://api.tvmaze.com/singlesearch/shows?q=${showName}&embed=episodes`)
-    .pipe(map(data => this.transformToIShowEpisode(data)))
-  }  
-
-  private transformToIShowEpisode(data: IShowEpisodesData){
-      return{
-        img: data._embedded.episodes[0].image.medium,
-        name: data._embedded.episodes[0].name,
-        summary: data._embedded.episodes[0].summary.replace(/<[^>]*>/g, '')
-      }
+    .pipe(map(data => this.transformToIShowDetails(data)))
+  }
+  
+  private transformToIShowDetails(data: IApiResponseData){
+    let showEpisodes: { img: string; name: string; summary: string; }[] = [];
+    data._embedded.episodes.forEach(element => {
+      showEpisodes.push({
+        img: element.image.medium,
+        name: element.name,
+        summary: element.summary.replace(/<[^>]*>/g, '')
+      })
+    })
+    return {
+      name: data.name,
+      episodes: showEpisodes
+    }
   }
 
 }

--- a/src/app/show-episodes/show-episodes.component.html
+++ b/src/app/show-episodes/show-episodes.component.html
@@ -1,12 +1,14 @@
-<div *ngIf="!episode.name">
+<div *ngIf="current.episodes.length == 0">
     No data available
 </div>
 
-<div *ngIf="episode.name">
-    <h1>Episodes</h1>    
-    <h4>{{episode.name}}</h4>
-    <img [src]="episode.img"/>        
-    <p>{{episode.summary}}</p>
-</div>   
+<div *ngIf="current.episodes.length > 0">
+    <h1>Episodes</h1>
+    <div *ngFor="let episode of current.episodes">
+        <h4>{{episode.name}}</h4>
+        <img [src]="episode.img"/>
+        <p>{{episode.summary}}</p>
+    </div>
+</div>
 
 

--- a/src/app/show-episodes/show-episodes.component.ts
+++ b/src/app/show-episodes/show-episodes.component.ts
@@ -1,7 +1,6 @@
 import { Component, Input, OnInit } from '@angular/core';
 import { Subscriber } from 'rxjs';
-import { IShowEpisodes } from '../ishow-episodes';
-
+import { IShowDetailsData } from '../ishow-details-data';
 
 @Component({
   selector: 'app-show-episodes',
@@ -10,12 +9,11 @@ import { IShowEpisodes } from '../ishow-episodes';
 })
 export class ShowEpisodesComponent implements OnInit {
 
-  @Input() episode: IShowEpisodes
-  constructor() { 
-    this.episode = {
-      img:'',
+  @Input() current: IShowDetailsData
+  constructor() {
+    this.current = {
       name: '',
-      summary: ''
+      episodes: []
     }
   }
 


### PR DESCRIPTION
- Added IApiResponseData interface to represent response from TV Maze API (extend this in future when adding more show details)
- Added list of episodes to IShowDetails interface
- Changed getShowDetails in ShowDetailsService to include embedded episodes and transform response data to IShowDetailsData interface
- Removed the no longer needed getEpisodes function from ShowDetailsService (was doing the same query as getShowDetails)
- Removed the no longer needed IShowEpisodesData and IShowEpisodes interfaces (handled by IApiResponseData and IShowEpisodesData instead)
- Changed show-episodes-component.html to loop over list of episodes instead of displaying single episode

To add more show details in the future, add fields to IShowDetailsData interface, IApiResponseData interface, showDetails in AppComponent and transformToIShowDetails in ShowDetailsService